### PR TITLE
fix: instagram url parameters

### DIFF
--- a/toutatis/core.py
+++ b/toutatis/core.py
@@ -14,7 +14,7 @@ def getUserId(username,sessionsId):
     cookies = {'sessionid': sessionsId}
     headers = {'User-Agent': 'Instagram 64.0.0.14.96'}
     api = requests.get(
-        f'https://www.instagram.com/{username}/?__a=1',
+        f'https://www.instagram.com/{username}/?__a=1&__d=dis',
         headers=headers,
         cookies=cookies
     )


### PR DESCRIPTION
**Fix:**
La requête dans la fonction `getUserId()` ne fonctionnait plus suite aux modifications portées par Instagram.
L'ajout du paramètre `&__d=dis` permet l'exécution du programme comme prévu.
Il semblerait qu'Instagram s'attende désormais à ce qu'il ne soit pas vide.

**Proof:**
=> https://www.instagram.com/valdsullyvan/?__a=1
```
for (;;);{
    "__ar": 1,
    "error": 1357004,
    "errorSummary": "Désolé, une erreur s’est produite.",
    "errorDescription": "Essayez de fermer, puis d’ouvrir à nouveau la fenêtre de votre navigateur.",
    "payload": null
}
```
=> https://www.instagram.com/valdsullyvan/?__a=1&__d=dis
```
"logging_page_id": "profilePage_1223854394",
    "show_suggested_profiles": false,
    "graphql": {
        "user": {
            "biography": "@echelon.records \nBilletterie Vald Tour 2022 🔽",
[...]
```

>Ref: https://stackoverflow.com/a/72675083/14288283