### PR TITLE
fix(core): add cookies back to get userId

### DIFF
--- a/toutatis/core.py
+++ b/toutatis/core.py
@@ -15,6 +15,7 @@ def getUserId(username,sessionsId):
     api = requests.get(
         f'https://i.instagram.com/api/v1/users/web_profile_info/?username={username}',
         headers=headers,
+        cookies={'sessionid': sessionsId}
     )
     try:
         if api.status_code == 404:


### PR DESCRIPTION
## Issue 
The `https://i.instagram.com/api/v1/users/web_profile_info/?username=` endpoint is authenticated.  
Actual version can't get `userId` when retrieving data as JSON : 
```
Traceback (most recent call last):
  File "/usr/local/bin/toutatis", line 33, in <module>
    sys.exit(load_entry_point('toutatis==1.26', 'console_scripts', 'toutatis')())
  File "/usr/local/lib/python3.10/dist-packages/toutatis-1.26-py3.10.egg/toutatis/core.py", line 83, in main
KeyError: 'user'
```

## Patch
We use the `cookie` variable to authenticate ourselves on the endpoint and get what we want.