### PR TITLE
Display proper not found message instead of showing python error

### DIFF
--- a/toutatis/core.py
+++ b/toutatis/core.py
@@ -81,7 +81,7 @@ def main():
     sessionsId=args.sessionid
 
     infos = getInfo(args.username, sessionsId)
-    if not infos["user"]:
+    if not infos.get("user"):
         exit(infos["error"])
 
     infos=infos["user"]


### PR DESCRIPTION
Previously invalid usernames would result in this Python error message:
![image](https://github.com/user-attachments/assets/0b94e5ed-b02c-4e79-b278-018ff43db443)

Changed it to the intended error message:
![image](https://github.com/user-attachments/assets/f07741ac-c81b-42b5-a725-3b85a4e5f121)
