### PR TITLE
Remove IGTV posts print statement due to deprecation (#159)

### DIFF
--- a/toutatis/core.py
+++ b/toutatis/core.py
@@ -122,7 +122,6 @@ def main():
     # print("Number of tag in posts : "+str(infos["following_tag_count"]))
     if infos["external_url"]:
         print("External url           : " + infos["external_url"])
-    print("IGTV posts             : " + str(infos["total_igtv_videos"]))
     print("Biography              : " + (f"""\n{" " * 25}""").join(infos["biography"].split("\n")))
     print("Linked WhatsApp        : " + str(infos["is_whatsapp_linked"]))
     print("Memorial Account       : " + str(infos["is_memorialized"]))


### PR DESCRIPTION
This PR removes the line:

```
print("IGTV posts             : " + str(infos["total_igtv_videos"]))
```

IGTV has been deprecated, and the associated key `total_igtv_videos` is no longer returned in the API response.
Keeping this line causes a KeyError when running the script.

By removing it, we prevent the error and ensure the script runs smoothly.

Issue Reference:
- Fixes #159

Changes:
- Removed IGTV print statement.

Impact:
- No functional changes beyond preventing the error.