### PR TITLE
Fix KeyError for total_igtv_videos field

### DIFF
--- a/toutatis/core.py
+++ b/toutatis/core.py
@@ -122,7 +122,7 @@ def main():
     # print("Number of tag in posts : "+str(infos["following_tag_count"]))
     if infos["external_url"]:
         print("External url           : " + infos["external_url"])
-    print("IGTV posts             : " + str(infos["total_igtv_videos"]))
+    print("IGTV posts             : " + str(infos.get("total_igtv_videos", "N/A")))
     print("Biography              : " + (f"""\n{" " * 25}""").join(infos["biography"].split("\n")))
     print("Linked WhatsApp        : " + str(infos["is_whatsapp_linked"]))
     print("Memorial Account       : " + str(infos["is_memorialized"]))


### PR DESCRIPTION
- Replace direct key access with .get() method to handle missing fields gracefully
- Prevents crash when Instagram API doesn't return total_igtv_videos field
- Shows 'N/A' instead of crashing when field is not available