### PR TITLE
Improve error handling and email visibility in core.py

### DIFF
--- a/toutatis/core.py
+++ b/toutatis/core.py
@@ -122,7 +122,7 @@ def main():
     # print("Number of tag in posts : "+str(infos["following_tag_count"]))
     if infos["external_url"]:
         print("External url           : " + infos["external_url"])
-    print("IGTV posts             : " + str(infos["total_igtv_videos"]))
+    print("IGTV posts             : " + str(infos.get("total_igtv_videos", 0)))
     print("Biography              : " + (f"""\n{" " * 25}""").join(infos["biography"].split("\n")))
     print("Linked WhatsApp        : " + str(infos["is_whatsapp_linked"]))
     print("Memorial Account       : " + str(infos["is_memorialized"]))
@@ -131,6 +131,10 @@ def main():
     if "public_email" in infos.keys():
         if infos["public_email"]:
             print("Public Email           : " + infos["public_email"])
+        else:
+            print("Public Email           : None")
+    else:
+        print("Public Email           : Not available")
 
     if "public_phone_number" in infos.keys():
         if str(infos["public_phone_number"]):
@@ -160,7 +164,9 @@ def main():
             if other_infos["user"]["obfuscated_email"]:
                 print("Obfuscated email       : " + other_infos["user"]["obfuscated_email"])
             else:
-                print("No obfuscated email found")
+                print("Obfuscated email       : None")
+        else:
+            print("Obfuscated email       : Not available")
 
         if "obfuscated_phone" in other_infos["user"].keys():
             if str(other_infos["user"]["obfuscated_phone"]):


### PR DESCRIPTION
## Issue Fixed

The tool was crashing on certain accounts (e.g., private accounts without IGTV data) due to a KeyError when accessing missing API fields.

### Error Example
```
Informations about     : [username redacted]
userID                 : [userID redacted]
Full Name              : [full name redacted]
Verified               : False | Is buisness Account : False
Is private Account     : True
Follower               : 7 | Following : 12
Number of posts        : 0
Traceback (most recent call last):
  File ".../toutatis/core.py", line 125, in main
    print("IGTV posts             : " + str(infos["total_igtv_videos"]))
                                            ~~~~~^^^^^^^^^^^^^^^^^^^^^
KeyError: 'total_igtv_videos'
```

## Changes Made

1. **Fixed KeyError** - Used safe dictionary access (`.get()`) for `total_igtv_videos` field
2. **Enhanced public email reporting** - Always indicate presence/absence of public email
3. **Enhanced obfuscated email reporting** - Always indicate presence/absence of obfuscated email

## Benefits

- ✅ Prevents crashes when processing accounts with missing API fields
- ✅ Improves robustness and user experience
- ✅ Provides clearer, more consistent output

## Files Changed

- `toutatis/core.py`

## Testing

Verified on multiple Instagram usernames including:
- Private accounts
- Accounts without IGTV content
- Various account types

No crashes observed, and email status is now always reported consistently.