### PR TITLE
Fix KeyError for removed IGTV field, add Python 3.10 compatibility note

### DIFF
--- a/toutatis/core.py
+++ b/toutatis/core.py
@@ -122,7 +122,7 @@ def main():
     # print("Number of tag in posts : "+str(infos["following_tag_count"]))
     if infos["external_url"]:
         print("External url           : " + infos["external_url"])
-    print("IGTV posts             : " + str(infos["total_igtv_videos"]))
+    print("IGTV posts             : " + str(infos.get("total_igtv_videos", 0)))
     print("Biography              : " + (f"""\n{" " * 25}""").join(infos["biography"].split("\n")))
     print("Linked WhatsApp        : " + str(infos["is_whatsapp_linked"]))
     print("Memorial Account       : " + str(infos["is_memorialized"]))


### PR DESCRIPTION
### Summary
Instagram removed IGTV and the field `total_igtv_videos` is no longer returned by the API.  
Toutatis currently crashes with:

KeyError: 'total_igtv_videos'

### Fix
Replaced the direct access with a safe `.get()` call:

Before:
    infos["total_igtv_videos"]

After:
    infos.get("total_igtv_videos", 0)

### Additional Notes
- Tested successfully on Python 3.10
- Prevents crashes and preserves backward compatibility
- Tool does not work on Python 3.11+ due to dependency breaks; the README may need compatibility updates.

This PR ensures Toutatis remains functional after Instagram's IGTV removal.